### PR TITLE
Store mandrill response to Mail::Message

### DIFF
--- a/lib/mandrill_dm.rb
+++ b/lib/mandrill_dm.rb
@@ -2,6 +2,7 @@ require "mandrill"
 
 require "mandrill_dm/message"
 require "mandrill_dm/delivery_method"
+require "mandrill_dm/mail_message_ext"
 require "mandrill_dm/railtie" if defined? Rails
 
 module MandrillDm

--- a/lib/mandrill_dm/delivery_method.rb
+++ b/lib/mandrill_dm/delivery_method.rb
@@ -10,6 +10,7 @@ module MandrillDm
       mandrill = Mandrill::API.new(MandrillDm.configuration.api_key)
       message = Message.new(mail).to_json
       result = mandrill.messages.send(message)
+      mail.store_mandrill_response(result)
     end
   end
 end

--- a/lib/mandrill_dm/mail_message_ext.rb
+++ b/lib/mandrill_dm/mail_message_ext.rb
@@ -1,0 +1,12 @@
+require "mail"
+
+# extend Mail::Message to store mandrill response
+class Mail::Message
+  def store_mandrill_response(result)
+    @mandrill_response = result
+  end
+
+  def mandrill_response
+    @mandrill_response
+  end
+end

--- a/spec/mandrill_dm/delivery_method_spec.rb
+++ b/spec/mandrill_dm/delivery_method_spec.rb
@@ -8,9 +8,10 @@ describe MandrillDm::DeliveryMethod do
   end
 
   context 'api' do
+    let(:mandrill_response) { [{ "_id" => "mandrill_response_id" }] }
     before(:each) do
       @api = double('Mandrill::API')
-      @api.stub_chain(:messages, :send).and_return({})
+      @api.stub_chain(:messages, :send).and_return(mandrill_response)
     end
 
     it 'gets instantiated' do
@@ -34,6 +35,18 @@ describe MandrillDm::DeliveryMethod do
           bcc 'name@domain.tld'
         end
       }.not_to raise_error
+    end
+
+    it "store mandrill response to Mail::Message" do
+      Mandrill::API.stub(:new).and_return(@api)
+      mail = Mail.deliver do
+        from 'John Doe <name@domain.tld>'
+        body 'Hello world!'
+        subject 'A Test'
+        to 'name@domain.tld'
+        bcc 'name@domain.tld'
+      end
+      expect(mail.mandrill_response).to eq(mandrill_response)
     end
   end
 end


### PR DESCRIPTION
I use this gem to access mandrill API.

I want to use mandrill API's response to store mail message id to db.

I think my English is poor to understand. Please read code! :grin:
