### PR TITLE
Send as text when no html part is found

### DIFF
--- a/lib/mandrill_dm/message.rb
+++ b/lib/mandrill_dm/message.rb
@@ -19,7 +19,7 @@ module MandrillDm
     end
 
     def html
-      @mail.html_part ? @mail.html_part.body.decoded : @mail.body.decoded
+      @mail.html_part ? @mail.html_part.body.decoded : nil
     end
 
     def subaccount
@@ -31,7 +31,7 @@ module MandrillDm
     end
 
     def text
-      @mail.multipart? ? (@mail.text_part ? @mail.text_part.body.decoded : nil) : nil
+      @mail.multipart? ? (@mail.text_part ? @mail.text_part.body.decoded : nil) : @mail.body.decoded
     end
 
     def to

--- a/mandrill_dm.gemspec
+++ b/mandrill_dm.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
   s.name = 'mandrill_dm'
-  s.version = '1.1.0'
-  s.date = '2014-04-05'
+  s.version = '1.1.1'
+  s.date = '2014-10-24'
   s.summary = "A basic Mandrill delivery method for Rails."
   s.description = "An easy way to transition from the SMTP delivery method in Rails to Mandrill's API, while still using ActionMailer."
   s.authors = "Jonathan Berglund"


### PR DESCRIPTION
This commit fixes a problem with sending text only emails.
It was sending text only templates as html and thus compromising their formatting.
