### PR TITLE
Update `MandrillDm::DeliveryMethod` to capture the response from the Mandrill API

### DIFF
--- a/lib/mandrill_dm/delivery_method.rb
+++ b/lib/mandrill_dm/delivery_method.rb
@@ -1,15 +1,15 @@
 module MandrillDm
   class DeliveryMethod
-    attr_accessor :settings
+    attr_accessor :settings, :response
 
     def initialize(options = {})
-      self.settings = options
+      @settings = options
     end
 
     def deliver!(mail)
-      mandrill = Mandrill::API.new(MandrillDm.configuration.api_key)
-      message = Message.new(mail).to_json
-      result = mandrill.messages.send(message)
+      mandrill_api = Mandrill::API.new(MandrillDm.configuration.api_key)
+      message = Message.new(mail)
+      @response = mandrill_api.messages.send(message.to_json)
     end
   end
 end

--- a/spec/mandrill_dm/delivery_method_integration_spec.rb
+++ b/spec/mandrill_dm/delivery_method_integration_spec.rb
@@ -1,0 +1,88 @@
+require 'spec_helper'
+
+describe MandrillDm::DeliveryMethod, 'integrating with the Mail API', integration: true do
+
+  before(:each) do
+    Mail.defaults { delivery_method MandrillDm::DeliveryMethod }
+  end
+
+  context '#deliver' do
+    let(:from_name)       { 'From Name' }
+    let(:from_email)      { 'from@domain.tld' }
+    let(:from)            { "#{from_name} <#{from_email}>" }
+    let(:to)              { (1..3).map { |i| "To #{i} <to_#{i}@domain.tld>" } }
+    let(:cc)              { (1..3).map { |i| "Cc #{i} <cc_#{i}@domain.tld>" } }
+    let(:bcc)             { (1..3).map { |i| "Bcc #{i} <bcc_#{i}@domain.tld>" } }
+    let(:message_subject) { 'Some Message Subject' }
+    let(:body)            { 'Some Message Body' }
+
+    let(:api)      { instance_double(Mandrill::API) }
+    let(:messages) { instance_double(Mandrill::Messages, send: {}) }
+
+    before(:each) do
+      allow(Mandrill::API).to receive(:new).and_return(api)
+      allow(api).to receive(:messages).and_return(messages)
+    end
+
+    subject do
+      example = self
+      Mail.deliver do
+        from      example.from
+        to        example.to
+        cc        example.cc
+        bcc       example.bcc
+        subject   example.message_subject
+        body      example.body
+      end
+    end
+
+    it 'instantiates the Mandrill API with the configured API key' do
+      expect(Mandrill::API).to receive(:new).with(MandrillDm.configuration.api_key).and_return(api)
+
+      subject
+    end
+
+    it 'successfully sends a message' do
+      allow(Mandrill::API).to receive(:new).and_call_original
+
+      expect { subject }.not_to raise_error
+    end
+
+    context 'the sent message' do
+      it 'contains the provided from address' do
+        expect(messages).to receive(:send).with(hash_including(from_name: from_name, from_email: from_email))
+
+        subject
+      end
+
+      %w{ to cc bcc }.each do |recipient_type|
+        it 'contains the provided #{recipient_type} addresses' do
+          expect(messages).to receive(:send) do |message_hash|
+            (1..3).each do |i|
+              expected_recipient = {
+                email: "#{recipient_type}_#{i}@domain.tld",
+                name:  "#{recipient_type.capitalize} #{i}",
+                type:  recipient_type
+              }
+              expect(message_hash[:to]).to include(expected_recipient)
+            end
+          end
+
+          subject
+        end
+      end
+
+      it 'contains the provided subject' do
+        expect(messages).to receive(:send).with(hash_including(subject: message_subject))
+
+        subject
+      end
+
+      it 'contains the provided body as HTML' do
+        expect(messages).to receive(:send).with(hash_including(html: body))
+
+        subject
+      end
+    end
+  end
+end

--- a/spec/mandrill_dm/delivery_method_spec.rb
+++ b/spec/mandrill_dm/delivery_method_spec.rb
@@ -1,39 +1,58 @@
 require 'spec_helper'
 
 describe MandrillDm::DeliveryMethod do
-  before(:each) do
-    Mail.defaults do
-      delivery_method MandrillDm::DeliveryMethod
+  let(:options)         { { 'some_option_key' => 'some option value' } }
+  let(:delivery_method) { MandrillDm::DeliveryMethod.new(options) }
+
+  context '#initialize' do
+    it 'sets passed options to `settings` attr_accesor' do
+      expect(delivery_method.settings).to eql(options)
     end
   end
 
-  context 'api' do
+  context '#deliver!' do
+    let(:mail_message) { instance_double(Mail::Message) }
+    let(:api_key)      { '1234567890' }
+    let(:dm_message)   { instance_double(MandrillDm::Message) }
+    let(:response)     { { 'some_response_key' => 'some response value' } }
+    let(:messages)     { instance_double(Mandrill::Messages, send: response) }
+    let(:api)          { instance_double(Mandrill::API, messages: messages) }
+
     before(:each) do
-      @api = double('Mandrill::API')
-      @api.stub_chain(:messages, :send).and_return({})
+      allow(Mandrill::API).to receive(:new).and_return(api)
+      allow(MandrillDm).to receive_message_chain(:configuration, :api_key).and_return(api_key)
+      allow(MandrillDm::Message).to receive(:new).and_return(dm_message)
     end
 
-    it 'gets instantiated' do
-      Mandrill::API.should receive(:new).with('1234567890').and_return(@api)
-      Mail.deliver do
-        from 'John Doe <name@domain.tld>'
-        body 'Hello world!'
-        subject 'A Test'
-        to 'name@domain.tld'
-        bcc 'name@domain.tld'
-      end
+    subject { delivery_method.deliver!(mail_message) }
+
+    it 'instantiates the Mandrill API with the configured API key' do
+      expect(Mandrill::API).to receive(:new).with(api_key).and_return(api)
+
+      subject
     end
 
-    it 'sends a message' do
-      expect {
-        Mail.deliver do
-          from 'John Doe <name@domain.tld>'
-          body 'Hello world!'
-          subject 'A Test'
-          to 'name@domain.tld'
-          bcc 'name@domain.tld'
-        end
-      }.not_to raise_error
+    it 'creates a Mandrill message from the Mail message' do
+      expect(MandrillDm::Message).to receive(:new).with(mail_message).and_return(dm_message)
+
+      subject
+    end
+
+    it 'sends the JSON version of the Mandrill message via the API' do
+      allow(dm_message).to receive(:to_json).and_return('Some message JSON')
+      expect(messages).to receive(:send).with('Some message JSON')
+
+      subject
+    end
+
+    it 'returns the response from sending the message' do
+      expect(subject).to eql(response)
+    end
+
+    it 'establishes the response for subsequent use' do
+      subject
+
+      expect(delivery_method.response).to eql(response)
     end
   end
 end


### PR DESCRIPTION
Example usage would be something like:

```
message  = FooMailer.build(email).deliver_now
response = message.delivery_method.response
```

The response json will be formatted as indicated here:
https://mandrillapp.com/api/docs/messages.html

Update the specs for `MandrillDm::DeliveryMethod` to better test the class behavior. Also, this splits tests into class tests and integration tests.  These tests are taken (and only slightly modified) from the [MYOB-Technology fork](https://github.com/MYOB-Technology/mandrill_dm) of mandrill_dm.  Credit for these tests goes to @dueckes.
